### PR TITLE
Catalogue info revision 1

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -18,7 +18,7 @@
   "Upload schema bundle (.zip OR .json) Or drag and drop one": "Upload schema bundle (.zip OR .json) Or drag and drop one",
   "View Schema": "View Schema",
   "Edit Schema": "Edit Schema",
-  "Generate Readme": "Generate Readme",
+  "Generate Text Readme": "Generate Text Readme",
   "Generate Markdown Readme": "Generate Markdown Readme",
   "Generate Data Entry Excel": "Generate Data Entry Excel",
   "Schemas are an important piece of data documentation. Schemas work...": "Schemas are an important piece of data documentation. Schemas work together with a dataset and describe data features such as column names, units, and descriptions etc.",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -270,5 +270,11 @@
   "Data Standard": "Data Standard",
   "Data Standards": "Data Standards",
   "Add Data Standards": "Add Data Standards",
-  "Remove overlay": "Remove overlay"
+  "Remove overlay": "Remove overlay",
+  "scenario": "scenario",
+  "Update": "Update",
+  "Save": "Save",
+  "Add catalogue information": "Add catalogue information",
+  "Catalogue Information": "Catalogue Information",
+  "Include catalogue information in markdown readme": "Include catalogue information in markdown readme"
 }

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -268,5 +268,11 @@
   "Data Standard": "Norme de données",
   "Data Standards": "Normes de données",
   "Add Data Standards": "Ajouter des normes de données",
-  "Remove overlay": "Supprimer la superposition"
+  "Remove overlay": "Supprimer la superposition",
+  "scenario": "scénario",
+  "Update": "Mise à jour",
+  "Save": "Sauvegarder",
+  "Add catalogue information": "Ajouter des informations sur le catalogue",
+  "Catalogue Information": "Informations sur le catalogue",
+  "Include catalogue information in markdown readme": "Inclure les informations du catalogue dans le fichier Lisez-moi Markdown"
 }

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -17,7 +17,7 @@
   "Upload schema bundle (.zip OR .json) Or drag and drop one": "Téléchargez un ensemble de schémas (.zip OU .json) ou faites-en un glisser-déposer",
   "View Schema": "Afficher le schéma",
   "Edit Schema": "Modifier le schéma",
-  "Generate Readme": "Générer un fichier Readme",
+  "Generate Text Readme": "Générer du texte Lisez-moi",
   "Generate Markdown Readme": "Générer un fichier Readme Markdown",
   "Generate Data Entry Excel": "Générer Excel de saisie de données",
   "Schemas are an important piece of data documentation. Schemas work...": "Les schémas sont un élément important de la documentation des données. Les schémas fonctionnent avec un ensemble de données et décrivent les caractéristiques des données telles que les noms de colonnes, les unités et les descriptions, etc.",

--- a/src/CatalogueInfo/CatalogueInfo.jsx
+++ b/src/CatalogueInfo/CatalogueInfo.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { useTranslation } from "react-i18next";
 import { Box, Button, Typography } from "@mui/material";
 import { CheckBox, CheckBoxOutlineBlank } from "@mui/icons-material";
 import CatalogueInfoForm from "./CatalogueInfoForm";
@@ -8,6 +9,7 @@ import { CustomPalette } from "../constants/customPalette";
 
 function CatalogueInfo() {
   const [isOpen, setIsOpen] = useState(false);
+  const { t } = useTranslation();
   const { storedValue, saveToLocalStorage } = useLocalStorage(CATALOGUE_INFO_KEY);
   return (
     <>
@@ -15,7 +17,9 @@ function CatalogueInfo() {
         {storedValue ? (
           <>
             <CheckBox sx={{ color: CustomPalette.PRIMARY }} />
-            <Typography>{storedValue.scenario} scenario</Typography>
+            <Typography>
+              {storedValue.scenario} {t("scenario")}
+            </Typography>
           </>
         ) : (
           <CheckBoxOutlineBlank sx={{ color: CustomPalette.PRIMARY }} />
@@ -27,7 +31,7 @@ function CatalogueInfo() {
           onClick={() => setIsOpen(true)}
           sx={{ flexGrow: 1 }}
         >
-          {storedValue ? "Update" : "Add catalogue information"}
+          {storedValue ? t("Update") : t("Add catalogue information")}
         </Button>
       </Box>
       <CatalogueInfoForm

--- a/src/CatalogueInfo/CatalogueInfo.jsx
+++ b/src/CatalogueInfo/CatalogueInfo.jsx
@@ -7,7 +7,7 @@ import useLocalStorage from "../hooks/useLocalStorage";
 import { CATALOGUE_INFO_KEY } from "../constants/catalogueInfo";
 import { CustomPalette } from "../constants/customPalette";
 
-function CatalogueInfo() {
+function CatalogueInfo({ isDisabled }) {
   const [isOpen, setIsOpen] = useState(false);
   const { t } = useTranslation();
   const { storedValue, saveToLocalStorage } = useLocalStorage(CATALOGUE_INFO_KEY);
@@ -28,6 +28,7 @@ function CatalogueInfo() {
           size="small"
           variant="contained"
           color="navButton"
+          disabled={isDisabled}
           onClick={() => setIsOpen(true)}
           sx={{ flexGrow: 1 }}
         >

--- a/src/CatalogueInfo/CatalogueInfoForm.jsx
+++ b/src/CatalogueInfo/CatalogueInfoForm.jsx
@@ -7,12 +7,14 @@ import {
   Typography
 } from "@mui/material";
 import React from "react";
+import { useTranslation } from "react-i18next";
 import { useForm } from "react-hook-form";
 import CustomFormInput from "../components/CustomFormInput";
 import { catalogueInfoFormFields, catalogueScenarios } from "../constants/catalogueInfo";
 import CustomSelect from "../components/CustomSelect";
 
 function CatalogueInfoForm({ catalogueData, isOpen, handleClose, saveToLocalStorage }) {
+  const { t } = useTranslation();
   const {
     control,
     handleSubmit,
@@ -49,9 +51,9 @@ function CatalogueInfoForm({ catalogueData, isOpen, handleClose, saveToLocalStor
   return (
     <div>
       <Dialog open={isOpen} onClose={handleClose} maxWidth="xs" fullWidth>
-        <DialogTitle sx={{ pb: 0 }}>Catalogue Information</DialogTitle>
+        <DialogTitle sx={{ pb: 0 }}>{t("Catalogue Information")}</DialogTitle>
         <Typography sx={{ px: "24px" }}>
-          Include catalogue information in markdown readme
+          {t("Include catalogue information in markdown readme")}
         </Typography>
         <form onSubmit={handleSubmit(onSubmit)}>
           <DialogContent>
@@ -95,7 +97,7 @@ function CatalogueInfoForm({ catalogueData, isOpen, handleClose, saveToLocalStor
           </DialogContent>
           <DialogActions sx={{ px: "24px", pb: "20px", pt: 0 }}>
             <Button variant="outlined" color="navButton" onClick={handleClose}>
-              Cancel
+              {t("Cancel")}
             </Button>
             <Button
               type="submit"
@@ -103,7 +105,7 @@ function CatalogueInfoForm({ catalogueData, isOpen, handleClose, saveToLocalStor
               color="navButton"
               disabled={!selectedScenario}
             >
-              Save
+              {t("Save")}
             </Button>
           </DialogActions>
         </form>

--- a/src/Landing/AccordionList.js
+++ b/src/Landing/AccordionList.js
@@ -243,20 +243,29 @@ const AccordionList = () => {
               sx={buttonStyles}
               disabled={disableButtonCheck}
             >
-              {t("Generate Readme")}
+              {t("Generate Text Readme")}
             </Button>
-            <Box sx={{ marginTop: "30px", width: "100%", maxWidth: "300px" }}>
-              <CatalogueInfo />
-            </Box>
-            <Button
-              variant="contained"
-              color="navButton"
-              onClick={handleClickMarkdownReadme}
-              sx={buttonStyles}
-              disabled={disableButtonCheck}
+            <Box
+              sx={{
+                padding: "12px",
+                marginTop: "30px",
+                width: "100%",
+                maxWidth: "276px",
+                borderRadius: "4px",
+                border: `1px solid ${CustomPalette.PRIMARY}`
+              }}
             >
-              {t("Generate Markdown Readme")}
-            </Button>
+              <CatalogueInfo isDisabled={disableButtonCheck} />
+              <Button
+                variant="contained"
+                color="navButton"
+                onClick={handleClickMarkdownReadme}
+                sx={{ ...buttonStyles, marginTop: "12px" }}
+                disabled={disableButtonCheck}
+              >
+                {t("Generate Markdown Readme")}
+              </Button>
+            </Box>
             <GenerateDataEntryExcel
               rawFile={rawFile}
               setLoading={setLoading}

--- a/src/Landing/UseASchemaAccordionItem.js
+++ b/src/Landing/UseASchemaAccordionItem.js
@@ -163,7 +163,7 @@ const UseASchemaAccordionItem = () => {
             sx={buttonStyles}
             disabled={disableButtonCheck}
           >
-            {t("Generate Readme")}
+            {t("Generate Text Readme")}
           </Button>
           <Button
             variant="contained"


### PR DESCRIPTION
This PR includes the following changes:

- Disable catalogue info button when there is no uploaded schema
- Connect catalogue info to markdown readme by grouping them and adding a border around them
- Rename "Generate Readme" button to "Generate Text Readme"
- Add missing catalogue info translation