### PR TITLE
Add quotes to units in oca file

### DIFF
--- a/src/ViewSchema/useExportLogicV2.js
+++ b/src/ViewSchema/useExportLogicV2.js
@@ -241,7 +241,7 @@ const useExportLogicV2 = () => {
     buildText += "ADD Unit ATTRS";
 
     attributesList.forEach((item, index) => {
-      buildText += ` ${item}=${data[1][index].Unit}`;
+      buildText += ` ${item}="${data[1][index].Unit}"`;
     });
 
     buildText += "\n";


### PR DESCRIPTION
This PR sanitizes units in OCA file by wrapping them with quotes. By adding quotes, disallowed characters such as ^ in units will not cause any errors.