### PR TITLE
Attribute and entry code ordering in markdown readme

### DIFF
--- a/src/StartSchema/useZipParser.js
+++ b/src/StartSchema/useZipParser.js
@@ -190,7 +190,7 @@ const useZipParser = () => {
         Flagged: root?.flagged_attributes?.includes(item),
         List: attributesWithListType.includes(item),
         Type: root?.attributes?.[item],
-        Unit: units?.attribute_units?.[item]
+        Unit: units?.attribute_units?.[item] || units?.attribute_unit?.[item]
       });
 
       const newRowForCharacterEncoding = { Attribute: item };

--- a/src/ViewSchema/markdownReadmeUtils.js
+++ b/src/ViewSchema/markdownReadmeUtils.js
@@ -72,8 +72,6 @@ export const generateSchemaQuickView = ({
   currentLanguageCode,
   defaultLanguageCode
 }) => {
-  // Label and information overlays will always exist even if attributes don't have a label and description
-  // In case of no label or description, their values will be empty string
   const informationOverlay = layers.find(
     (layer) =>
       layer.layerName.includes("information") &&
@@ -88,8 +86,8 @@ export const generateSchemaQuickView = ({
 
   const columns = ["Attribute", "Label", "Description"];
   const rows = attributeNames.map((attribute) => {
-    const label = labelOverlay.attribute_labels[attribute];
-    const description = informationOverlay.attribute_information[attribute];
+    const label = labelOverlay?.attribute_labels?.[attribute] || "";
+    const description = informationOverlay?.attribute_information?.[attribute] || "";
     return [attribute, label, description];
   });
 
@@ -123,7 +121,12 @@ export const generateInternationalSchemaInformation = (
   return markdownContent.join("");
 };
 
-export const generateEntryCodeTables = (layers, languages, languageCodeLookupMap) => {
+export const generateEntryCodeTables = (
+  layers,
+  languages,
+  languageCodeLookupMap,
+  orderingOverlay = null
+) => {
   const markdownContent = ["## Selection lists\n\n"];
   const columns = ["Entry code", "Label"];
 
@@ -144,13 +147,17 @@ export const generateEntryCodeTables = (layers, languages, languageCodeLookupMap
         const rows = [];
         markdownContent.push(`#### ${attribute} entry codes\n\n`);
         const entryCodeToLabelMap = entryOverlay.attribute_entries[attribute];
+        // Use entry code ordering if present
+        const hasEntryCodeOrdering =
+          orderingOverlay?.entry_code_ordering?.[attribute]?.length > 0;
+        const entryCodes = hasEntryCodeOrdering
+          ? orderingOverlay.entry_code_ordering[attribute]
+          : Object.keys(entryCodeToLabelMap);
 
-        for (const entryCode in entryCodeToLabelMap) {
-          if (Object.prototype.hasOwnProperty.call(entryCodeToLabelMap, entryCode)) {
-            const label = entryCodeToLabelMap[entryCode];
-            rows.push([entryCode, label]);
-          }
-        }
+        entryCodes.forEach((entryCode) => {
+          const label = entryCodeToLabelMap[entryCode];
+          rows.push([entryCode, label]);
+        });
 
         markdownContent.push(generateTable(columns, rows), "\n\n");
       }
@@ -166,7 +173,8 @@ export const generateLanguageSpecificSchemaDetailsTable = ({
   layers,
   attributeNames,
   languages,
-  languageCodeLookupMap
+  languageCodeLookupMap,
+  orderingOverlay = null
 }) => {
   const markdownContent = ["## Language-specific schema details\n\n"];
   const columns = ["Attribute", "Label", "Description", "List"];
@@ -192,10 +200,19 @@ export const generateLanguageSpecificSchemaDetailsTable = ({
       const description = informationOverlay?.attribute_information?.[attribute] || "";
 
       // Check if an attribute is a list (has entries and entry codes)
+      // If entry code ordering is present, use it to generate the ordered list of entry code labels
+      const hasEntryCodeOrdering =
+        orderingOverlay?.entry_code_ordering?.[attribute]?.length > 0;
       const entryCodeToLabelMap = entryOverlay?.attribute_entries[attribute];
-      const list = entryCodeToLabelMap
-        ? Object.values(entryCodeToLabelMap).join(", ")
-        : "Not a list";
+      let list = "Not a list";
+
+      if (entryCodeToLabelMap) {
+        list = hasEntryCodeOrdering
+          ? orderingOverlay.entry_code_ordering[attribute]
+              .map((entryCode) => entryCodeToLabelMap[entryCode])
+              .join(", ")
+          : Object.values(entryCodeToLabelMap).join(", ");
+      }
 
       row.push(label, description, list);
       return row;
@@ -297,6 +314,7 @@ export const generateLanguageIndependentSchemaDetailsTable = ({
   return markdownContent.join("");
 };
 
+// For ZIP schema bundle
 export const generateSAIDTable = (captureBaseSAID, layerToSAIDMap) => {
   const markdownContent = ["## Schema SAIDs\n\n"];
   markdownContent.push(`**Capture base**: ${captureBaseSAID}\n\n`);
@@ -309,6 +327,23 @@ export const generateSAIDTable = (captureBaseSAID, layerToSAIDMap) => {
       rows.push([layer, layerToSAIDMap[layer]]);
     }
   }
+
+  markdownContent.push(generateTable(columns, rows), "\n\n");
+
+  return markdownContent.join("");
+};
+
+// For JSON schema
+export const generateSAIDTableForJson = (captureBaseSAID, layers) => {
+  const markdownContent = ["## Schema SAIDs\n\n"];
+  markdownContent.push(`**Capture base**: ${captureBaseSAID}\n\n`);
+
+  const columns = ["Layer", "SAID", "Type"];
+  const rows = [];
+
+  layers.forEach((layer) => {
+    rows.push([layer.name, layer.digest, layer.type]);
+  });
 
   markdownContent.push(generateTable(columns, rows), "\n\n");
 

--- a/src/ViewSchema/useGenerateMarkdownReadMeFromJson.js
+++ b/src/ViewSchema/useGenerateMarkdownReadMeFromJson.js
@@ -15,7 +15,7 @@ import {
   generateInternationalSchemaInformation,
   generateLanguageIndependentSchemaDetailsTable,
   generateLanguageSpecificSchemaDetailsTable,
-  generateSAIDTable,
+  generateSAIDTableForJson,
   generateSchemaInformation,
   generateSchemaQuickView
 } from "./markdownReadmeUtils";
@@ -30,7 +30,9 @@ const getModifiedLayer = (overlay) => {
 };
 
 const useGenerateMarkdownReadMeFromJson = () => {
-  const { languages } = useContext(Context);
+  const { languages, OCAPackage } = useContext(Context);
+  const orderingOverlay = OCAPackage?.extensions?.[0]?.overlays?.ordering;
+  const hasAttributeOrdering = orderingOverlay?.attribute_ordering?.length > 0;
 
   // Ensuring that the currently selected site language is one of the languages of the schema
   const currentLanguageCode = languages.some(
@@ -43,9 +45,12 @@ const useGenerateMarkdownReadMeFromJson = () => {
     let fileContent = "";
     const captureBaseOverlay = schemaData.capture_base;
     const captureBaseSAID = captureBaseOverlay.d;
-    const attributeNames = Object.keys(captureBaseOverlay.attributes);
-    const layerToSAIDMap = {};
+    const attributeNames = hasAttributeOrdering
+      ? orderingOverlay?.attribute_ordering
+      : Object.keys(captureBaseOverlay.attributes);
+
     const layers = [];
+    const layersForSaidTable = [];
 
     for (const overlayName of Object.keys(schemaData.overlays)) {
       const overlay = schemaData.overlays[overlayName];
@@ -53,15 +58,39 @@ const useGenerateMarkdownReadMeFromJson = () => {
         overlay.forEach((langSpecificOverlay) => {
           const modifiedLayer = getModifiedLayer(langSpecificOverlay);
           const layerNameWithoutVersion = `${modifiedLayer.layerName.split("/")[0]}${modifiedLayer.language ? ` (${modifiedLayer.language})` : ""}`;
-          layerToSAIDMap[layerNameWithoutVersion] = modifiedLayer.digest;
+          layersForSaidTable.push({
+            name: layerNameWithoutVersion,
+            digest: modifiedLayer.digest,
+            type: langSpecificOverlay.type
+          });
           layers.push(modifiedLayer);
         });
       } else {
         const modifiedLayer = getModifiedLayer(overlay);
         const layerNameWithoutVersion = `${modifiedLayer.layerName.split("/")[0]}${modifiedLayer.language ? ` (${modifiedLayer.language})` : ""}`;
-        layerToSAIDMap[layerNameWithoutVersion] = modifiedLayer.digest;
+        layersForSaidTable.push({
+          name: layerNameWithoutVersion,
+          digest: modifiedLayer.digest,
+          type: overlay.type
+        });
         layers.push(modifiedLayer);
       }
+    }
+
+    // Include extension overlays if any
+    if (OCAPackage?.extensions?.length > 0) {
+      OCAPackage.extensions.forEach((extension) => {
+        const extensionOverlays = extension.overlays;
+        const overlayNames = Object.keys(extensionOverlays);
+        overlayNames.forEach((overlayName) => {
+          const overlay = extensionOverlays[overlayName];
+          layersForSaidTable.push({
+            name: overlayName,
+            digest: overlay.d,
+            type: overlay.type
+          });
+        });
+      });
     }
 
     const metaOverlayCurrentLanguage = layers.find(
@@ -88,7 +117,12 @@ const useGenerateMarkdownReadMeFromJson = () => {
       languages,
       languageNameToAlpha3Codes
     );
-    fileContent += generateEntryCodeTables(layers, languages, languageNameToAlpha3Codes);
+    fileContent += generateEntryCodeTables(
+      layers,
+      languages,
+      languageNameToAlpha3Codes,
+      orderingOverlay
+    );
     fileContent += generateLanguageIndependentSchemaDetailsTable({
       layers,
       captureBaseOverlay,
@@ -98,9 +132,10 @@ const useGenerateMarkdownReadMeFromJson = () => {
       layers,
       attributeNames,
       languages,
-      languageCodeLookupMap: languageNameToAlpha3Codes
+      languageCodeLookupMap: languageNameToAlpha3Codes,
+      orderingOverlay
     });
-    fileContent += generateSAIDTable(captureBaseSAID, layerToSAIDMap);
+    fileContent += generateSAIDTableForJson(captureBaseSAID, layersForSaidTable);
     fileContent += generateCreationTimestamp();
 
     const fileName = `${metaOverlayCurrentLanguage.name.split(" ")[0]}_OCA_schema.md`;

--- a/src/constants/utils.js
+++ b/src/constants/utils.js
@@ -117,6 +117,8 @@ export const replaceAttributeCharsInJsonString = (jsonString, parsed = false) =>
     if (parsedJson.type.split("/")[2] === "unit") {
       if (parsedJson.attribute_units) {
         parsedJson.attribute_units = replaceCharsInKeys(parsedJson.attribute_units);
+      } else if (parsedJson.attribute_unit) {
+        parsedJson.attribute_unit = replaceCharsInKeys(parsedJson.attribute_unit);
       }
     }
   }
@@ -212,6 +214,10 @@ export const replaceAttributeCharsInParsedJson = (parsedJson) => {
   if (modifiedParsedJson?.overlays?.unit?.attribute_units) {
     modifiedParsedJson.overlays.unit.attribute_units = replaceCharsInKeys(
       modifiedParsedJson.overlays.unit.attribute_units
+    );
+  } else if (modifiedParsedJson.overlays.unit.attribute_unit) {
+    modifiedParsedJson.overlays.unit.attribute_unit = replaceCharsInKeys(
+      modifiedParsedJson.overlays.unit.attribute_unit
     );
   }
 


### PR DESCRIPTION
This PR contains the following changes:
- attribute and entry code ordering in markdown readme
- show extension overlays in schema SAID table
- add "type" column in schema SAID table
- get unit information from attribute_unit for OCA v1.1 schema bundle (JSON) 