### PR TITLE
Keep dots in attribute names

### DIFF
--- a/src/constants/utils.js
+++ b/src/constants/utils.js
@@ -22,11 +22,7 @@ export const getDescriptiveFileName = (schemaDescription, commonFileName) => {
 };
 
 // Helper function to replace specified characters in object keys
-export const replaceCharsInKeys = (
-  obj,
-  charsToReplace = [".", ","],
-  replacement = "_"
-) => {
+export const replaceCharsInKeys = (obj, charsToReplace = [","], replacement = "_") => {
   if (!obj) return obj;
 
   const pattern = new RegExp(`[${charsToReplace.join("")}]`, "g");


### PR DESCRIPTION
We no longer need to replace dots in attribute names as HCF now allows them in attributes.