### PR TITLE
fix the atrribute label mismatching bug

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -511,7 +511,7 @@ function App() {
   useEffect(() => {
     if (jsonRawFile.length > 0) {
       const newMatchingRowData = [];
-      attributesList.forEach((item, index) => {
+      attributesList.forEach((item) => {
         // if matchingRowData has data, use it
         const matchingRow = matchingRowData.find((obj) => obj.Attribute === item);
         const newObj = {
@@ -522,8 +522,10 @@ function App() {
           newObj.Dataset = matchingRow.Dataset;
         }
         languages.forEach((lang) => {
-          newObj[lang] = lanAttributeRowData?.[lang]?.[index]?.Label;
-        });
+            const languageRows = lanAttributeRowData?.[lang] || [];
+            const matchingLangRow = languageRows.find((row) => row?.Attribute === item);
+            newObj[lang] = matchingLangRow?.Label || "";
+          });
         newMatchingRowData.push(newObj);
       });
       setMatchingRowData(newMatchingRowData);


### PR DESCRIPTION
The parsing function assigned the labels based on the loop index variable which sometimes didn't match the attribute list. So I added logic to match the attribute to the label while parsing.