### PR TITLE
Ensure dataset rows get loaded before initial validation in DEW

### DIFF
--- a/src/OCADataValidator/OCADataValidatorCheck.js
+++ b/src/OCADataValidator/OCADataValidatorCheck.js
@@ -1327,7 +1327,10 @@ const OCADataValidatorCheck = ({
               onCellKeyDown={onCellKeyDown}
               suppressFieldDotNotation
               onGridReady={() => {
-                handleValidate();
+                // Wait for row data to be loaded before validating
+                setTimeout(() => {
+                  handleValidate();
+                }, 0);
               }}
             />
           </div>


### PR DESCRIPTION
The Verify button was staying disabled on Safari because the dataset was being validated before it was fully loaded. This PR fixes that issue.