### PR TITLE
fixed the entry code drop down menu issue

### DIFF
--- a/src/OCADataValidator/OCADataValidatorCheck.js
+++ b/src/OCADataValidator/OCADataValidatorCheck.js
@@ -934,7 +934,7 @@ const OCADataValidatorCheck = ({
 
   useEffect(() => {
     const columns = [];
-    const LIMIT_ENTRYCODES_LENGTH = 20;
+    const LIMIT_ENTRYCODES_LENGTH = 50;
     const variableToCheck = attributesList;
     if (datasetRawFile.length === 0) {
       // avoid resetting parent header on every render — only update when different


### PR DESCRIPTION
the drop down menu of entry codes wasn't displaying the english/french lable of the code, the issue was a hard coded limit on the number of entry codes an attribute can have. The attribute causing the issue had more than 20 entry codes which was going over the limit and not allowing that attribute to go through to the function that mapped the entry codes to their enlish/french labels. For now I have just increased the limit to 50, we can consider changing the implementation to not have a hard coded limit.