### PR TITLE
fixed the next button on the attribute match screen

### DIFF
--- a/src/OCADataValidator/AttributeMatch.js
+++ b/src/OCADataValidator/AttributeMatch.js
@@ -312,12 +312,12 @@ const AttributeMatch = () => {
   }, [type, t]);
 
   // helper that checks if all attributes are matched to their respective datasets and disables the forward button if not
-  const areAllColumnsMatched = useCallback(
-    () =>
-      matchingRowData.length > 0 &&
-      matchingRowData.every((row) => row.Dataset && row.Dataset !== ""),
-    [matchingRowData]
-  );
+  // const areAllColumnsMatched = useCallback(
+  //   () =>
+  //     matchingRowData.length > 0 &&
+  //     matchingRowData.every((row) => row.Dataset && row.Dataset !== ""),
+  //   [matchingRowData]
+  // );
 
   return (
     <>
@@ -332,7 +332,6 @@ const AttributeMatch = () => {
         isForward
         pageForward={handleSavePage}
         middleText={t("You must match your dataset columns (variables) to the attributes in your schema. The verifier attempts to match names automatically. If there are mismatches or unassigned matches you can correct that here.")}
-        disableForward={!areAllColumnsMatched()}
       />
       <Box
         sx={{


### PR DESCRIPTION
removed the function that was checking if all the attributes are matched to disable the next button. Now the user can move forward without matching all the attributes.