### PR TITLE
fixed the entry code verification issue

### DIFF
--- a/src/OCADataValidator/utils/matchRules.js
+++ b/src/OCADataValidator/utils/matchRules.js
@@ -63,6 +63,11 @@ function matchBoolean(dataStr) {
 }
 
 export function matchFormat(attrType, pattern, dataStr, hasEntryCodes) {
+  // If there are entry codes, we don't need to match the format.
+  // Entry codes are handled in the validator.js file.
+  if (hasEntryCodes) {
+    return true;
+  }
   if (attrType.includes("DateTime")) {
     return matchDatetime(pattern, dataStr);
   }


### PR DESCRIPTION
the data format and entry code were not compatible, the verification was failing if the data entry was from the allowed entry codes but the regex wasn't matching the entry code. I removed the format (regex) check for entry code verification.