### PR TITLE
Feat/linkml attributes

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -11,6 +11,7 @@ import LearnAboutDataVerification from "./OCADataValidator/LearnAboutDataVerific
 import OCAMerge from "./OCAMerge/OCAMerge";
 import { MultiSchemaProvider } from "./schema/schemaContext";
 import SessionDraftManager from "./components/SessionDraftManager";
+import SchemaUploadWarningPopup from "./SchemaTranslator/SchemaUploadWarningPopup";
 import { getCurrentTheme } from "./utils/themeDetector";
 import { CustomPalette } from "./constants/customPalette";
 import { overlayItems } from "./constants/constants";
@@ -88,6 +89,7 @@ function App() {
   const [selectedOverlaysOCAFile1, setSelectedOverlaysOCAFile1] = useState({});
   const [selectedOverlaysOCAFile2, setSelectedOverlaysOCAFile2] = useState({});
   const [datasetDropMessage, setDatasetDropMessage] = useState({ message: "", type: "" });
+  const [jsonDropMessage, setJsonDropMessage] = useState({ message: "", type: "" });
 
   // Theme state
   const [currentTheme, setCurrentTheme] = useState(getCurrentTheme());
@@ -268,6 +270,8 @@ function App() {
               setTargetResult,
               datasetDropMessage,
               setDatasetDropMessage,
+              jsonDropMessage,
+              setJsonDropMessage,
               notToVerifyAttributes,
               setNotToVerifyAttributes,
               currentSchemaId,
@@ -287,6 +291,7 @@ function App() {
             >
               <BrowserRouter>
                 <SessionDraftManager />
+                <SchemaUploadWarningPopup />
                 <Routes>
                   <Route path="/" element={<Landing />} />
                   <Route

--- a/src/Landing/LandingDropZone.js
+++ b/src/Landing/LandingDropZone.js
@@ -23,81 +23,77 @@ const LandingDropZone = ({
       sx={{
         width: "100%",
         display: "flex",
-        flexDirection: "row",
+        flexDirection: "column",
         justifyContent: "center",
         alignItems: "center"
       }}
-      {...getRootProps({ className: "dropzone" })}
     >
-      <input {...getInputProps()} />
-      <Card
+      <Box
         sx={{
-          border: 1,
-          padding: "8px",
-          paddingLeft: "20px",
-          paddingRight: "20px",
-          height: "80px",
-          width: "300px",
-          marginTop: 3,
+          width: "100%",
           display: "flex",
           flexDirection: "row",
           justifyContent: "center",
-          alignItems: "center",
-          backgroundColor: "#CDCDCD",
-          alignSelf: "center",
-          cursor: "pointer"
+          alignItems: "center"
         }}
-        onMouseOver={handleHover}
-        onMouseLeave={handleHoverLeave}
-        onDragOver={handleDragOver}
-        onDragLeave={handleDragLeave}
+        {...getRootProps({ className: "dropzone" })}
       >
-        {/* {dropMessage?.message.length > 0 && (
-          <Alert
-            severity={dropMessage?.type}
-            style={{
-              position: "absolute",
-              zIndex: 9999,
-              left: "70%",
-              transform: "translate(-50%, -110%)",
-            }}
-          >
-            {dropMessage?.message}
-          </Alert>
-        )} */}
-
-        <CardContent>
-          {loading === true ? (
-            <LoopIcon
-              sx={{
-                color: CustomPalette.GREY_300,
-                m: 2,
-                fontSize: "60px",
-                animation: spinningAnimation,
-                transition: "all 0.2s ease-in-out"
-              }}
-            />
-          ) : dropDisabled === true ? (
-            <CheckCircleOutlineIcon
-              sx={{
-                m: 2,
-                fontSize: "60px",
-                color: CustomPalette.PRIMARY
-              }}
-            />
-          ) : (
-            <Tooltip title={t("Drag-and-Drop/Click-to-Find")} arrow>
-              <Typography sx={{ fontSize: "16px", fontWeight: "700" }}>
-                {t("Upload Schema")}
-                <br />
-                {t("(.zip or .json for OCA)")}
-                <br />
-                {t("(.yaml or .yml for LinkML)")}
-              </Typography>
-            </Tooltip>
-          )}
-        </CardContent>
-      </Card>
+        <input {...getInputProps()} />
+        <Card
+          sx={{
+            border: 1,
+            padding: "8px",
+            paddingLeft: "20px",
+            paddingRight: "20px",
+            height: "80px",
+            width: "300px",
+            marginTop: 3,
+            display: "flex",
+            flexDirection: "row",
+            justifyContent: "center",
+            alignItems: "center",
+            backgroundColor: "#CDCDCD",
+            alignSelf: "center",
+            cursor: "pointer"
+          }}
+          onMouseOver={handleHover}
+          onMouseLeave={handleHoverLeave}
+          onDragOver={handleDragOver}
+          onDragLeave={handleDragLeave}
+        >
+          <CardContent>
+            {loading === true ? (
+              <LoopIcon
+                sx={{
+                  color: CustomPalette.GREY_300,
+                  m: 2,
+                  fontSize: "60px",
+                  animation: spinningAnimation,
+                  transition: "all 0.2s ease-in-out"
+                }}
+              />
+            ) : dropDisabled === true ? (
+              <CheckCircleOutlineIcon
+                sx={{
+                  m: 2,
+                  fontSize: "60px",
+                  color: CustomPalette.PRIMARY
+                }}
+              />
+            ) : (
+              <Tooltip title={t("Drag-and-Drop/Click-to-Find")} arrow>
+                <Typography sx={{ fontSize: "16px", fontWeight: "700" }}>
+                  {t("Upload Schema")}
+                  <br />
+                  {t("(.zip or .json for OCA)")}
+                  <br />
+                  {t("(.yaml or .yml for LinkML)")}
+                </Typography>
+              </Tooltip>
+            )}
+          </CardContent>
+        </Card>
+      </Box>
     </Box>
   );
 };

--- a/src/OCADataValidator/useHandleSchemaFileDrop.js
+++ b/src/OCADataValidator/useHandleSchemaFileDrop.js
@@ -1,11 +1,14 @@
-import { useCallback, useContext, useEffect, useState } from "react";
+import { useCallback, useContext, useEffect } from "react";
 import yaml from "js-yaml";
 import { messages } from "../constants/messages";
 import { ADC, SENSITIVE } from "../constants/constants";
 import { Context } from "../App";
 import { useMultiSchema } from "../schema/schemaContext";
 import { replaceAttributeCharsInParsedJson } from "../utils/helpers";
-import { mapLinkMLToOCABundle } from "../SchemaTranslator/mapLinkMLToOCABundle";
+import {
+  mapLinkMLToOCABundle,
+  findMissingLinkMLEnums
+} from "../SchemaTranslator/mapLinkMLToOCABundle";
 import { transformToPackage } from "../SchemaTranslator/linkMLToOCA";
 import {
   getPackageBundleId,
@@ -13,6 +16,11 @@ import {
   getRootCaptureBaseId
 } from "../utils/packageUtils";
 import { parseOcaZipArrayBuffer } from "../utils/ocaZipImport";
+import {
+  isLandingJsonSchema,
+  isLandingYamlSchema,
+  isLandingZipSchema
+} from "../utils/landingSchemaUpload";
 // eslint-disable-next-line import/prefer-default-export
 export const useHandleSchemaFileDrop = (
   firstTimeDisplayWarning,
@@ -35,39 +43,42 @@ export const useHandleSchemaFileDrop = (
     setMatchingRowData,
     firstTimeMatchingRef,
     targetResult,
-    setTargetResult
+    setTargetResult,
+    jsonDropMessage,
+    setJsonDropMessage
   } = useContext(Context);
-  const { clearAllSchemas, switchToSchema, loadAllSchemasFromOcaPackage, setOcaPackage } = useMultiSchema();
+  const { clearAllSchemas, switchToSchema, loadAllSchemasFromOcaPackage, setOcaPackage } =
+    useMultiSchema();
   // useZipParser removed - data processing now handled by loadAllSchemasFromOcaPackage -> OCAParser
 
-  const [jsonDropMessage, setJsonDropMessage] = useState({
-    message: "",
-    type: ""
-  });
-
-  const finishUploadUi = useCallback(() => {
-    setJsonDropDisabled(true);
-    setJsonDropMessage({ message: "", type: "" });
-    setJsonLoading(false);
-    setDatasetLoading(false);
-    if (datasetRawFile.length === 0) {
-      setDatasetDropDisabled(false);
-    }
-    if (!jsonIsParsed) {
-      setJsonIsParsed(true);
-      setCurrentDataValidatorPage("SchemaViewDataValidator");
-    }
-  }, [
-    datasetRawFile.length,
-    jsonIsParsed,
-    setCurrentDataValidatorPage,
-    setDatasetDropDisabled,
-    setDatasetLoading,
-    setJsonDropDisabled,
-    setJsonDropMessage,
-    setJsonIsParsed,
-    setJsonLoading
-  ]);
+  const finishUploadUi = useCallback(
+    (options = {}) => {
+      setJsonDropDisabled(true);
+      if (!options.preserveDropMessage) {
+        setJsonDropMessage({ message: "", type: "" });
+      }
+      setJsonLoading(false);
+      setDatasetLoading(false);
+      if (datasetRawFile.length === 0) {
+        setDatasetDropDisabled(false);
+      }
+      if (!jsonIsParsed) {
+        setJsonIsParsed(true);
+        setCurrentDataValidatorPage("SchemaViewDataValidator");
+      }
+    },
+    [
+      datasetRawFile.length,
+      jsonIsParsed,
+      setCurrentDataValidatorPage,
+      setDatasetDropDisabled,
+      setDatasetLoading,
+      setJsonDropDisabled,
+      setJsonDropMessage,
+      setJsonIsParsed,
+      setJsonLoading
+    ]
+  );
 
   const overallLoading = useCallback(() => {
     setJsonLoading(true);
@@ -79,6 +90,7 @@ export const useHandleSchemaFileDrop = (
     setJsonDropDisabled(false);
     setSchemaRawFile([]);
     setMatchingRowData([]);
+    setJsonDropMessage({ message: "", type: "" });
     firstTimeMatchingRef.current = true;
     firstTimeDisplayWarning.current = true;
     setShowWarningCard(false);
@@ -95,188 +107,192 @@ export const useHandleSchemaFileDrop = (
             setTargetResult(e);
             const textDecoder = new TextDecoder("utf-8");
             const jsonString = textDecoder.decode(e.target.result);
-          const rawParse = coerceIfLegacyTopLevelBundle(JSON.parse(jsonString));
-          let jsonFile = null;
-          let ocaPackageData = null;
-          if (rawParse?.oca_bundle?.bundle) {
-            ocaPackageData = rawParse;
-            jsonFile = rawParse?.oca_bundle?.bundle;
-            setOcaPackage(rawParse);
-          } else if (rawParse?.schema?.[0]) {
-            jsonFile = rawParse?.schema?.[0];
-          } else {
-            jsonFile = rawParse;
-          }
-
-          if (!jsonFile) {
-            throw new Error("No JSON file found");
-          }
-
-          jsonFile = replaceAttributeCharsInParsedJson(jsonFile);
-
-          // ALSO ensure multi-schema ocaPackage is populated so validator always uses package root
-          try {
-            let pkgToSet = null;
-            if (ocaPackageData) {
-              pkgToSet = ocaPackageData;
-            } else if (jsonFile?.capture_base) {
-              pkgToSet = { bundle: jsonFile };
+            const rawParse = coerceIfLegacyTopLevelBundle(JSON.parse(jsonString));
+            let jsonFile = null;
+            let ocaPackageData = null;
+            if (rawParse?.oca_bundle?.bundle) {
+              ocaPackageData = rawParse;
+              jsonFile = rawParse?.oca_bundle?.bundle;
+              setOcaPackage(rawParse);
+            } else if (rawParse?.schema?.[0]) {
+              jsonFile = rawParse?.schema?.[0];
+            } else {
+              jsonFile = rawParse;
             }
 
-            if (pkgToSet) {
-              setOcaPackage(pkgToSet);
-              try {
-                loadAllSchemasFromOcaPackage(pkgToSet);
-                const rootId = getPackageBundleId(pkgToSet);
-                if (rootId) switchToSchema(rootId, pkgToSet);
-              } catch (err) {
-                // non-fatal; initialization failed but ocaPackage was set — downstream components
-                // should handle missing initialization defensively.
-                console.warn("useHandleSchemaFileDrop: loadAllSchemasFromOcaPackage failed", err);
+            if (!jsonFile) {
+              throw new Error("No JSON file found");
+            }
+
+            jsonFile = replaceAttributeCharsInParsedJson(jsonFile);
+
+            // ALSO ensure multi-schema ocaPackage is populated so validator always uses package root
+            try {
+              let pkgToSet = null;
+              if (ocaPackageData) {
+                pkgToSet = ocaPackageData;
+              } else if (jsonFile?.capture_base) {
+                pkgToSet = { bundle: jsonFile };
               }
+
+              if (pkgToSet) {
+                setOcaPackage(pkgToSet);
+                try {
+                  loadAllSchemasFromOcaPackage(pkgToSet);
+                  const rootId = getPackageBundleId(pkgToSet);
+                  if (rootId) switchToSchema(rootId, pkgToSet);
+                } catch (err) {
+                  // non-fatal; initialization failed but ocaPackage was set — downstream components
+                  // should handle missing initialization defensively.
+                  console.warn(
+                    "useHandleSchemaFileDrop: loadAllSchemasFromOcaPackage failed",
+                    err
+                  );
+                }
+              }
+            } catch (err) {
+              console.error("useHandleSchemaFileDrop: error setting ocaPackage", err);
             }
-          } catch (err) {
-            console.error("useHandleSchemaFileDrop: error setting ocaPackage", err);
-          }
 
-          const languageList = [];
-          const informationList = [];
-          const labelList = [];
-          const metaList = [];
-          const entryList = [];
-          const allJSONFiles = [];
-          let loadRoot;
-          let entryCodeSummary = {};
-          let conformance;
-          let characterEncoding;
-          let loadUnits;
-          let formatRules;
-          let cardinalityData;
-          let dataStandards;
+            const languageList = [];
+            const informationList = [];
+            const labelList = [];
+            const metaList = [];
+            const entryList = [];
+            const allJSONFiles = [];
+            let loadRoot;
+            let entryCodeSummary = {};
+            let conformance;
+            let characterEncoding;
+            let loadUnits;
+            let formatRules;
+            let cardinalityData;
+            let dataStandards;
 
-          // load up metadata file in OCA bundle
-          if (jsonFile?.overlays?.meta) {
-            metaList.push(...jsonFile.overlays.meta);
-            languageList.push(
-              ...jsonFile.overlays.meta.map((meta) => meta.language.slice(0, 2))
-            );
+            // load up metadata file in OCA bundle
+            if (jsonFile?.overlays?.meta) {
+              metaList.push(...jsonFile.overlays.meta);
+              languageList.push(
+                ...jsonFile.overlays.meta.map((meta) => meta.language.slice(0, 2))
+              );
 
-            // ONLY for README
-            const readmeMeta = jsonFile.overlays.meta.map((meta) => JSON.stringify(meta));
-            allJSONFiles.push(...readmeMeta);
-          }
-
-          if (jsonFile?.overlays?.information) {
-            informationList.push(...jsonFile.overlays.information);
-
-            // ONLY for README
-            const readmeInformation = jsonFile.overlays.information.map((information) =>
-              JSON.stringify(information)
-            );
-            allJSONFiles.push(...readmeInformation);
-          }
-
-          if (jsonFile?.overlays?.label) {
-            labelList.push(...jsonFile.overlays.label);
-
-            // ONLY for README
-            const readmeLabel = jsonFile.overlays.label.map((label) =>
-              JSON.stringify(label)
-            );
-            allJSONFiles.push(...readmeLabel);
-          }
-
-          if (jsonFile?.capture_base) {
-            const sensitiveOverlay =
-              ocaPackageData?.extensions?.[ADC]?.[
-                getRootCaptureBaseId(ocaPackageData)
-              ]?.overlays?.[SENSITIVE];
-
-            const sensitiveAttributes = Array.isArray(
-              sensitiveOverlay?.sensitive_attributes
-            )
-              ? sensitiveOverlay?.sensitive_attributes
-              : Array.isArray(jsonFile?.capture_base?.flagged_attributes)
-                ? jsonFile?.capture_base?.flagged_attributes
-                : [];
-
-            if (sensitiveAttributes?.length > 0) {
-              setShowWarningCard(true);
+              // ONLY for README
+              const readmeMeta = jsonFile.overlays.meta.map((meta) =>
+                JSON.stringify(meta)
+              );
+              allJSONFiles.push(...readmeMeta);
             }
-            loadRoot = { ...jsonFile.capture_base };
 
-            // ONLY for README
-            allJSONFiles.push(JSON.stringify(loadRoot));
-          }
+            if (jsonFile?.overlays?.information) {
+              informationList.push(...jsonFile.overlays.information);
 
-          if (jsonFile?.overlays?.unit) {
-            loadUnits = { ...jsonFile.overlays.unit };
+              // ONLY for README
+              const readmeInformation = jsonFile.overlays.information.map((information) =>
+                JSON.stringify(information)
+              );
+              allJSONFiles.push(...readmeInformation);
+            }
 
-            // ONLY for README
-            allJSONFiles.push(JSON.stringify(loadUnits));
-          }
+            if (jsonFile?.overlays?.label) {
+              labelList.push(...jsonFile.overlays.label);
 
-          if (jsonFile?.overlays?.conformance) {
-            conformance = { ...jsonFile.overlays.conformance };
+              // ONLY for README
+              const readmeLabel = jsonFile.overlays.label.map((label) =>
+                JSON.stringify(label)
+              );
+              allJSONFiles.push(...readmeLabel);
+            }
 
-            // ONLY for README
-            allJSONFiles.push(JSON.stringify(conformance));
-          }
+            if (jsonFile?.capture_base) {
+              const sensitiveOverlay =
+                ocaPackageData?.extensions?.[ADC]?.[getRootCaptureBaseId(ocaPackageData)]
+                  ?.overlays?.[SENSITIVE];
 
-          if (jsonFile?.overlays?.character_encoding) {
-            characterEncoding = { ...jsonFile.overlays.character_encoding };
+              const sensitiveAttributes = Array.isArray(
+                sensitiveOverlay?.sensitive_attributes
+              )
+                ? sensitiveOverlay?.sensitive_attributes
+                : Array.isArray(jsonFile?.capture_base?.flagged_attributes)
+                  ? jsonFile?.capture_base?.flagged_attributes
+                  : [];
 
-            // ONLY for README
-            allJSONFiles.push(JSON.stringify(characterEncoding));
-          }
+              if (sensitiveAttributes?.length > 0) {
+                setShowWarningCard(true);
+              }
+              loadRoot = { ...jsonFile.capture_base };
 
-          if (jsonFile?.overlays?.entry_code) {
-            entryCodeSummary = { ...jsonFile.overlays.entry_code };
+              // ONLY for README
+              allJSONFiles.push(JSON.stringify(loadRoot));
+            }
 
-            // ONLY for README
-            allJSONFiles.push(JSON.stringify(entryCodeSummary));
-          }
+            if (jsonFile?.overlays?.unit) {
+              loadUnits = { ...jsonFile.overlays.unit };
 
-          if (jsonFile?.overlays?.format) {
-            formatRules = { ...jsonFile.overlays.format };
+              // ONLY for README
+              allJSONFiles.push(JSON.stringify(loadUnits));
+            }
 
-            // ONLY for README
-            allJSONFiles.push(JSON.stringify(formatRules));
-          }
+            if (jsonFile?.overlays?.conformance) {
+              conformance = { ...jsonFile.overlays.conformance };
 
-          if (jsonFile?.overlays?.entry) {
-            entryList.push(...jsonFile.overlays.entry);
+              // ONLY for README
+              allJSONFiles.push(JSON.stringify(conformance));
+            }
 
-            // ONLY for README
-            const readmeEntry = jsonFile.overlays.entry.map((entry) =>
-              JSON.stringify(entry)
-            );
-            allJSONFiles.push(...readmeEntry);
-          }
+            if (jsonFile?.overlays?.character_encoding) {
+              characterEncoding = { ...jsonFile.overlays.character_encoding };
 
-          if (jsonFile?.overlays?.cardinality) {
-            cardinalityData = { ...jsonFile.overlays.cardinality };
+              // ONLY for README
+              allJSONFiles.push(JSON.stringify(characterEncoding));
+            }
 
-            // ONLY for README
-            allJSONFiles.push(JSON.stringify(cardinalityData));
-          }
+            if (jsonFile?.overlays?.entry_code) {
+              entryCodeSummary = { ...jsonFile.overlays.entry_code };
 
-          if (jsonFile?.overlays?.standard) {
-            dataStandards = { ...jsonFile.overlays.standard };
+              // ONLY for README
+              allJSONFiles.push(JSON.stringify(entryCodeSummary));
+            }
 
-            // ONLY for README
-            allJSONFiles.push(JSON.stringify(dataStandards));
-          }
+            if (jsonFile?.overlays?.format) {
+              formatRules = { ...jsonFile.overlays.format };
 
-          if (!languageList || languageList.length === 0) {
-            throw new Error("No language found in the JSON file");
-          }
+              // ONLY for README
+              allJSONFiles.push(JSON.stringify(formatRules));
+            }
 
-          // Data processing handled by loadAllSchemasFromOcaPackage (called during upload)
-          // which uses OCAParser to extract all schema data into MultiSchemaContext
-          
-          setZipToReadme(allJSONFiles);
-          finishUploadUi();
+            if (jsonFile?.overlays?.entry) {
+              entryList.push(...jsonFile.overlays.entry);
+
+              // ONLY for README
+              const readmeEntry = jsonFile.overlays.entry.map((entry) =>
+                JSON.stringify(entry)
+              );
+              allJSONFiles.push(...readmeEntry);
+            }
+
+            if (jsonFile?.overlays?.cardinality) {
+              cardinalityData = { ...jsonFile.overlays.cardinality };
+
+              // ONLY for README
+              allJSONFiles.push(JSON.stringify(cardinalityData));
+            }
+
+            if (jsonFile?.overlays?.standard) {
+              dataStandards = { ...jsonFile.overlays.standard };
+
+              // ONLY for README
+              allJSONFiles.push(JSON.stringify(dataStandards));
+            }
+
+            if (!languageList || languageList.length === 0) {
+              throw new Error("No language found in the JSON file");
+            }
+
+            // Data processing handled by loadAllSchemasFromOcaPackage (called during upload)
+            // which uses OCAParser to extract all schema data into MultiSchemaContext
+
+            setZipToReadme(allJSONFiles);
+            finishUploadUi();
           } catch (error) {
             setJsonDropMessage({ message: messages.uploadFail, type: "error" });
             setJsonLoading(false);
@@ -303,66 +319,86 @@ export const useHandleSchemaFileDrop = (
         }, 2500);
       }
     },
-    [datasetRawFile.length, finishUploadUi, jsonIsParsed, loadAllSchemasFromOcaPackage, setDatasetDropDisabled, setJsonDropMessage, setJsonLoading, setDatasetLoading, setOcaPackage, setShowWarningCard, setTargetResult, setZipToReadme, switchToSchema]
+    [
+      datasetRawFile.length,
+      finishUploadUi,
+      jsonIsParsed,
+      loadAllSchemasFromOcaPackage,
+      setDatasetDropDisabled,
+      setJsonDropMessage,
+      setJsonLoading,
+      setDatasetLoading,
+      setOcaPackage,
+      setShowWarningCard,
+      setTargetResult,
+      setZipToReadme,
+      switchToSchema
+    ]
   );
 
-  const handleZipDrop = useCallback((acceptedFiles) => {
-    try {
-      const reader = new FileReader();
+  const handleZipDrop = useCallback(
+    (acceptedFiles) => {
+      try {
+        const reader = new FileReader();
 
-      reader.onload = async (e) => {
-        setTargetResult(e);
-        try {
-          const { ocaPackage, allZipFiles, root, captureBase } =
-            await parseOcaZipArrayBuffer(e.target.result);
-          if (captureBase?.flagged_attributes?.length > 0) {
-            setShowWarningCard(true);
+        reader.onload = async (e) => {
+          setTargetResult(e);
+          try {
+            const { ocaPackage, allZipFiles, root, captureBase } =
+              await parseOcaZipArrayBuffer(e.target.result);
+            if (captureBase?.flagged_attributes?.length > 0) {
+              setShowWarningCard(true);
+            }
+            setOcaPackage(ocaPackage);
+            loadAllSchemasFromOcaPackage(ocaPackage);
+            switchToSchema(root, ocaPackage);
+            setZipToReadme(allZipFiles);
+            finishUploadUi();
+          } catch (err) {
+            console.warn(
+              "useHandleSchemaFileDrop: failed to parse zip as OCA package",
+              err
+            );
+            setJsonDropMessage({ message: messages.uploadFail, type: "error" });
+            setJsonLoading(false);
+            setDatasetLoading(false);
+            if (datasetRawFile.length === 0) {
+              setDatasetDropDisabled(false);
+            }
+            setTimeout(() => {
+              setJsonDropMessage({ message: "", type: "" });
+            }, 2500);
           }
-          setOcaPackage(ocaPackage);
-          loadAllSchemasFromOcaPackage(ocaPackage);
-          switchToSchema(root, ocaPackage);
-          setZipToReadme(allZipFiles);
-          finishUploadUi();
-        } catch (err) {
-          console.warn("useHandleSchemaFileDrop: failed to parse zip as OCA package", err);
-          setJsonDropMessage({ message: messages.uploadFail, type: "error" });
-          setJsonLoading(false);
-          setDatasetLoading(false);
-          if (datasetRawFile.length === 0) {
-            setDatasetDropDisabled(false);
-          }
-          setTimeout(() => {
-            setJsonDropMessage({ message: "", type: "" });
-          }, 2500);
+        };
+
+        reader.readAsArrayBuffer(acceptedFiles[0]);
+      } catch (error) {
+        setJsonDropMessage({ message: messages.uploadFail, type: "error" });
+        setJsonLoading(false);
+        setDatasetLoading(false);
+        if (datasetRawFile.length === 0) {
+          setDatasetDropDisabled(false);
         }
-      };
-
-      reader.readAsArrayBuffer(acceptedFiles[0]);
-    } catch (error) {
-      setJsonDropMessage({ message: messages.uploadFail, type: "error" });
-      setJsonLoading(false);
-      setDatasetLoading(false);
-      if (datasetRawFile.length === 0) {
-        setDatasetDropDisabled(false);
+        setTimeout(() => {
+          setJsonDropMessage({ message: "", type: "" });
+        }, 2500);
       }
-      setTimeout(() => {
-        setJsonDropMessage({ message: "", type: "" });
-      }, 2500);
-    }
-  }, [
-    datasetRawFile.length,
-    finishUploadUi,
-    loadAllSchemasFromOcaPackage,
-    setDatasetDropDisabled,
-    setDatasetLoading,
-    setJsonDropMessage,
-    setJsonLoading,
-    setOcaPackage,
-    setShowWarningCard,
-    setTargetResult,
-    setZipToReadme,
-    switchToSchema
-  ]);
+    },
+    [
+      datasetRawFile.length,
+      finishUploadUi,
+      loadAllSchemasFromOcaPackage,
+      setDatasetDropDisabled,
+      setDatasetLoading,
+      setJsonDropMessage,
+      setJsonLoading,
+      setOcaPackage,
+      setShowWarningCard,
+      setTargetResult,
+      setZipToReadme,
+      switchToSchema
+    ]
+  );
 
   const handleYamlDrop = useCallback(
     (acceptedFiles) => {
@@ -377,6 +413,7 @@ export const useHandleSchemaFileDrop = (
             const yamlString = e.target.result;
 
             const linkmlSchema = yaml.load(yamlString);
+            const missingEnums = findMissingLinkMLEnums(linkmlSchema);
             const bundle = mapLinkMLToOCABundle(linkmlSchema);
             const pkg = transformToPackage(bundle);
 
@@ -439,7 +476,15 @@ export const useHandleSchemaFileDrop = (
             switchToSchema(rootSchemaId, pkg);
             setZipToReadme(allJSONFiles);
 
-            finishUploadUi();
+            if (missingEnums.length > 0) {
+              setJsonDropMessage({
+                message: messages.linkmlMissingEnumsWarning(missingEnums),
+                type: "warning"
+              });
+              finishUploadUi({ preserveDropMessage: true });
+            } else {
+              finishUploadUi();
+            }
           } catch (error) {
             setJsonDropMessage({
               message: `${messages.uploadFail}: ${error.message}`,
@@ -485,6 +530,7 @@ export const useHandleSchemaFileDrop = (
       setJsonIsParsed,
       setJsonLoading,
       setOcaPackage,
+      setJsonDropMessage,
       setShowWarningCard,
       setTargetResult,
       setZipToReadme,
@@ -493,19 +539,12 @@ export const useHandleSchemaFileDrop = (
   );
 
   useEffect(() => {
-    if (schemaRawFile && schemaRawFile.length > 0 && schemaRawFile[0].path.includes(".json")) {
+    const file = schemaRawFile?.[0];
+    if (schemaRawFile && schemaRawFile.length > 0 && isLandingJsonSchema(file)) {
       handleJsonDrop(schemaRawFile);
-    } else if (
-      schemaRawFile &&
-      schemaRawFile.length > 0 &&
-      schemaRawFile[0].path.includes(".zip")
-    ) {
+    } else if (schemaRawFile && schemaRawFile.length > 0 && isLandingZipSchema(file)) {
       handleZipDrop(schemaRawFile);
-    } else if (
-      schemaRawFile &&
-      schemaRawFile.length > 0 &&
-      (schemaRawFile[0].path.includes(".yaml") || schemaRawFile[0].path.includes(".yml"))
-    ) {
+    } else if (schemaRawFile && schemaRawFile.length > 0 && isLandingYamlSchema(file)) {
       handleYamlDrop(schemaRawFile);
     } else if (schemaRawFile && schemaRawFile.length > 0) {
       setJsonDropMessage({ message: messages.uploadFail, type: "error" });

--- a/src/SchemaTranslator/README.md
+++ b/src/SchemaTranslator/README.md
@@ -146,8 +146,18 @@ Currently, the translator processes LinkML schemas **without validation**. While
 The translator currently:
 - Parses YAML content using `js-yaml` 
 - Processes `slots` and `enums` objects if present (defaults to empty objects if missing)
-- Maps available slots to OCA attributes with basic type conversion
+- Supports **induced class schemas** (with `attributes:` containing fully-resolved slot definitions)
+- Maps available slots/attributes to OCA attributes with basic type conversion
 - Generates overlays based on available LinkML properties
+
+### Supported Input Formats
+
+The translator accepts two LinkML YAML formats:
+
+1. **Standard schema** — top-level `slots:` dictionary (original behavior)
+2. **Induced class schema** — class-level `attributes:` dictionary with full definitions inline (e.g., output from `SchemaView.induced_class()`)
+
+Detection is automatic: if `slots:` is present it takes priority; otherwise `attributes:` is used if its values contain object definitions (with `range` or `description` fields).
 
 ### Validation Limitations
 

--- a/src/SchemaTranslator/SchemaUploadWarningPopup.js
+++ b/src/SchemaTranslator/SchemaUploadWarningPopup.js
@@ -1,0 +1,20 @@
+import React, { useContext } from "react";
+import { Typography } from "@mui/material";
+import { Context } from "../App";
+import ErrorPopup from "../ViewSchema/ErrorPopup";
+
+export default function SchemaUploadWarningPopup() {
+  const { jsonDropMessage, setJsonDropMessage } = useContext(Context);
+
+  if (jsonDropMessage?.type !== "warning" || !jsonDropMessage?.message) {
+    return null;
+  }
+
+  return (
+    <ErrorPopup onClose={() => setJsonDropMessage({ message: "", type: "" })}>
+      <Typography variant="h6" sx={{ p: 2, textAlign: "center" }}>
+        {jsonDropMessage.message}
+      </Typography>
+    </ErrorPopup>
+  );
+}

--- a/src/SchemaTranslator/mapLinkMLToOCABundle.js
+++ b/src/SchemaTranslator/mapLinkMLToOCABundle.js
@@ -338,12 +338,36 @@ export function buildOverlays(slots, enums, linkmlSchema) {
 }
 
 /**
+ * Extracts the slot/attribute definitions from a LinkML schema.
+ * Handles both standard schemas (top-level `slots:`) and induced class
+ * schemas (class-level `attributes:` with full definitions inline).
+ * @param {Object} linkmlSchema - The parsed LinkML YAML
+ * @returns {Object} A dictionary of slot_name -> slot_definition
+ */
+function extractSlotDefinitions(linkmlSchema) {
+  if (linkmlSchema.slots && Object.keys(linkmlSchema.slots).length > 0) {
+    return linkmlSchema.slots;
+  }
+
+  if (linkmlSchema.attributes && typeof linkmlSchema.attributes === "object") {
+    const firstValue = Object.values(linkmlSchema.attributes)[0];
+    if (firstValue && typeof firstValue === "object" && ("range" in firstValue || "description" in firstValue)) {
+      return linkmlSchema.attributes;
+    }
+  }
+
+  return {};
+}
+
+/**
  * Maps a LinkML schema to an OCA bundle structure.
+ * Supports both standard LinkML schemas (with top-level `slots:`) and
+ * induced class schemas (with `attributes:` containing full definitions).
  * @param {Object} linkmlSchema - The LinkML schema to convert
  * @returns {Object} An OCA bundle
  */
 export function mapLinkMLToOCABundle(linkmlSchema) {
-  const slots = linkmlSchema.slots || {};
+  const slots = extractSlotDefinitions(linkmlSchema);
   const enums = linkmlSchema.enums || {};
 
   // Extract OCA attributes and flagged attributes

--- a/src/SchemaTranslator/mapLinkMLToOCABundle.js
+++ b/src/SchemaTranslator/mapLinkMLToOCABundle.js
@@ -2,6 +2,28 @@
  * Maps LinkML schemas to OCA bundle structures.
  */
 
+const LINKML_PRIMITIVE_RANGES = new Set([
+  "string",
+  "integer",
+  "boolean",
+  "float",
+  "double",
+  "decimal",
+  "date",
+  "datetime",
+  "date_or_datetime",
+  "time",
+  "uriorcurie",
+  "uri",
+  "curie",
+  "ncname",
+  "nodeidentifier",
+  "object",
+  "jsonpointer",
+  "jsonpath",
+  "category"
+]);
+
 /**
  * Helper: build an overlay block only if data has keys
  * @param {string} type - The type of overlay
@@ -351,12 +373,32 @@ function extractSlotDefinitions(linkmlSchema) {
 
   if (linkmlSchema.attributes && typeof linkmlSchema.attributes === "object") {
     const firstValue = Object.values(linkmlSchema.attributes)[0];
-    if (firstValue && typeof firstValue === "object" && ("range" in firstValue || "description" in firstValue)) {
+    if (
+      firstValue &&
+      typeof firstValue === "object" &&
+      ("range" in firstValue || "description" in firstValue)
+    ) {
       return linkmlSchema.attributes;
     }
   }
 
   return {};
+}
+
+export function findMissingLinkMLEnums(linkmlSchema) {
+  const slots = extractSlotDefinitions(linkmlSchema);
+  const enums = linkmlSchema.enums || {};
+  const classes = linkmlSchema.classes || {};
+  const missing = new Set();
+
+  Object.values(slots).forEach((slot) => {
+    const range = slot?.range;
+    if (!range || LINKML_PRIMITIVE_RANGES.has(range)) return;
+    if (enums[range] || classes[range]) return;
+    if (range.endsWith("Enum")) missing.add(range);
+  });
+
+  return [...missing].sort();
 }
 
 /**

--- a/src/ViewSchema/ViewGrid.js
+++ b/src/ViewSchema/ViewGrid.js
@@ -157,14 +157,14 @@ export default function ViewGrid({
   }, [setLoading]);
 
   const computeRowPixelHeight = useCallback((data) => {
-    const opts = { compact: true };
-    const attrH = measureTextHeight(data?.Attribute || "", 104, opts);
-    const unitH = measureTextHeight(data?.Unit || "", 74, opts);
-    const typeH = measureTextHeight(data?.Type || "", 104, opts);
-    const labelH = measureTextHeight(data?.Label || "", 154, opts);
-    const descH = measureTextHeight(data?.Description || "", 334, opts);
+    const measureOpts = { lineHeight: 1.25, padding: "0" };
+    const attrH = measureTextHeight(data?.Attribute || "", 104, measureOpts);
+    const unitH = measureTextHeight(data?.Unit || "", 74, measureOpts);
+    const typeH = measureTextHeight(data?.Type || "", 104, measureOpts);
+    const labelH = measureTextHeight(data?.Label || "", 154, measureOpts);
+    const descH = measureTextHeight(data?.Description || "", 334, measureOpts);
     const maxH = Math.max(attrH, unitH, typeH, labelH, descH);
-    return Math.max(32, maxH + 14);
+    return Math.max(32, maxH + 4);
   }, []);
 
   const getRowHeight = useCallback(

--- a/src/constants/messages.js
+++ b/src/constants/messages.js
@@ -3,20 +3,19 @@ export const messages = {
   fileAccepted: "File accepted",
   parseUploadFail:
     "An error occurred while parsing the file. Please try again or create manually.",
-  noDataUploadFail:
-    "File has missing data. Please try another file or create manually.",
+  noDataUploadFail: "File has missing data. Please try another file or create manually.",
   tooLongUploadFail:
     "File upload taking too long to process. Please try again or create manually.",
-  uploadFail:
-    "An error occurred while uploading. Please try again or create manually.",
-  tooLargeUploadFail:
-    "File is too large. Please upload a file smaller than 10 MB.",
-  wrongTypeUploadFail:
-    "Invalid file type. Please upload a .csv file.",
+  uploadFail: "An error occurred while uploading. Please try again or create manually.",
+  tooLargeUploadFail: "File is too large. Please upload a file smaller than 10 MB.",
+  wrongTypeUploadFail: "Invalid file type. Please upload a .csv file.",
   fileRejectedFail: "File rejected. Please try again or create manually.",
   blankEntries:
     "Uploaded file contains blank entries. They will need to be deleted or updated on a future page.",
-  fileSizeLimit: "Please upload a file smaller than 1 MB. Only data headers in the first row are needed.",
+  fileSizeLimit:
+    "Please upload a file smaller than 1 MB. Only data headers in the first row are needed.",
   delimiterMismatchWarning: (expectedType, uploadedType) =>
     `Schema delimiter expects ${expectedType}, but you uploaded ${uploadedType}. You can continue, but parsing or validation results may not match the schema as expected.`,
+  linkmlMissingEnumsWarning: (enumNames) =>
+    `This LinkML schema references enumeration types that are not included: ${enumNames.join(", ")}. Entry codes for the affected attributes will not be generated. Include the missing enum definitions from the parent schema.`
 };

--- a/src/utils/measureTextLines.js
+++ b/src/utils/measureTextLines.js
@@ -27,6 +27,8 @@ export function measureTextHeight(text, maxWidthPx, options = {}) {
   const compact = options.compact === true;
   const el = getMeasureEl(compact);
   el.style.width = `${maxWidthPx}px`;
+  el.style.lineHeight = String(options.lineHeight ?? (compact ? 1 : 1.5));
+  el.style.padding = options.padding ?? (compact ? "0" : "8px");
   el.textContent = str;
   const height = el.offsetHeight;
   el.textContent = "";


### PR DESCRIPTION
Warn users when they upload an **induced LinkML schema** (e.g. `MimsMisip.yaml` from `mixs.yaml`) that references **enum types not included in the file**. Upload and translation still succeed; entry codes for affected attributes are not generated.

Example missing enums: `LibLayoutEnum`, `AssemblyQualEnum`, `NegContTypeEnum`, `TaxIdentEnum`.

## What changed

- **`findMissingLinkMLEnums`** in `mapLinkMLToOCABundle.js` — flags slot `range` values ending in `Enum` that aren’t defined in the schema’s `enums` section
- **`handleYamlDrop`** in `useHandleSchemaFileDrop.js` — runs detection after YAML parse; sets a context warning if any are missing
- **`SchemaUploadWarningPopup`** — modal popup (reuses `ErrorPopup`) shown app-wide via `App.js`
- **`jsonDropMessage`** moved to app context so the popup works from any upload entry point
- **File type detection** — YAML/JSON/ZIP routing uses `file.name` as well as `file.path` (browser uploads)

## What to review (functional changes)

Please focus on these areas; the rest is mostly Prettier on touched files:

| File | What to look at |
|------|-----------------|
| `mapLinkMLToOCABundle.js` | `findMissingLinkMLEnums` |
| `useHandleSchemaFileDrop.js` | `handleYamlDrop` warning block, `finishUploadUi({ preserveDropMessage })`, `useEffect` file-type helpers |
| `SchemaUploadWarningPopup.js` | New popup component |
| `App.js` | `jsonDropMessage` state + `<SchemaUploadWarningPopup />` |
| `messages.js` | `linkmlMissingEnumsWarning` copy |
